### PR TITLE
fix/pin dbt-entr version

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -2,4 +2,4 @@ packages:
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.2.0"]
   - git: "https://github.com/entralliance/dbt-entr.git"
-    revision: "dev"
+    revision: 0.0.2


### PR DESCRIPTION
This PR pins the version of dbt-entr as part of the effort to maintain stable releases of this package.
